### PR TITLE
bind mount /etc/passwd and /etc/group in readonly mode with portainer template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.ftpconfig

--- a/templates.json
+++ b/templates.json
@@ -16,6 +16,18 @@
     "image": "eri_dev:latest",
     "ports": [
       "8888/tcp"
-    ]
+  ],
+  "volumes": [
+      {
+          "container": "/etc/group",
+          "bind": "/etc/group",
+          "readonly": true
+      },
+      {
+          "container": "/etc/passwd",
+          "bind": "/etc/passwd",
+          "readonly": true
+      }
+  ]
   }
 ]


### PR DESCRIPTION
added readonly bind mounts for `/etc/passwd` and `/etc/group`. The read-only mode is available but not documented in the [portainer docs](http://portainer.readthedocs.io/en/stable/templates.html).