### PR TITLE
Increase shared memory size on GPU containers. Fixes #38.

### DIFF
--- a/app/launch.py
+++ b/app/launch.py
@@ -388,6 +388,10 @@ def launch(username, imagetype=GPU_DEV, jupyter_pwd=None, **kwargs):
     # proper runtime value and add an environment variable flag
     if imagetype in GPU_IMAGES:
         imagedict['runtime'] = 'nvidia'
+        # increasing shm_size to 8G. default if not set explicitly is 64M.
+        # this prevents bus error when running pytorch in docker containers
+        # see https://github.com/pytorch/pytorch/issues/2244
+        imagedict['shm_size'] = '8G'
         _update_environment(
             imagedict,
             'NVIDIA_VISIBLE_DEVICES',


### PR DESCRIPTION
explicitly set `imagedict['shm_size'] = '8G'` for GPU images to avoid bus error when running pytorch.
according to [docker docs](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources), the default value is 64M if not set explicitly. 