### PR TITLE
update href to valid fqdn for vpn connections. Fixes #33

### DIFF
--- a/app/launch.py
+++ b/app/launch.py
@@ -177,7 +177,7 @@ def active_eri_images(client=None, ignore_other_images=False):
                 c.attrs['HostConfig']['PortBindings']['8888/tcp'][0]['HostPort']
             )
 
-            d['jupyter_url'] = 'http://eri-gpu:{}'.format(port)
+            d['jupyter_url'] = 'http://eri-gpu.cho.elderresearch.com:{}'.format(port)
 
         if imagetype in R_IMAGES:
             # similarly for the rstudio server, go find the port from the
@@ -186,7 +186,7 @@ def active_eri_images(client=None, ignore_other_images=False):
                 c.attrs['HostConfig']['PortBindings']['8787/tcp'][0]['HostPort']
             )
 
-            d['rstudio_url'] = 'http://eri-gpu:{}'.format(port)
+            d['rstudio_url'] = 'http://eri-gpu.cho.elderresearch.com:{}'.format(port)
 
         # check for a username environment variable
         d['username'] = _env_lookup(c, 'USER')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -25,8 +25,8 @@
                     <td>{{ x.imagetype }}</td>
                     <td>{{ x.username }}</td>
                     <td>{{ x.image }}</td>
-                    <td><a href="{{ x.jupyter_url }}">{{ x.jupyter_url }}</a></td>
-                    <td><a href="{{ x.rstudio_url }}">{{ x.rstudio_url }}</a></td>
+                    <td><a href="{{ x.jupyter_url }}">{{ x.jupyter_url[:14] + x.jupyter_url[36:]}}</a></td>
+                    <td><a href="{{ x.rstudio_url }}">{{ x.rstudio_url[:14] + x.rstudio_url[36:]}}</a></td>
                     <td>{{ x.id[:10] }}</td>
                     <td>{{ x.uptime }}</td>
                     <td>


### PR DESCRIPTION
Updated `jupyter_url` and `rstudio_url` in dict returned by `launch.active_eri_images()` to eri-gpu.cho.elderresearch.com:[port]. Also, changed the template in app/templates/index.html to maintain the short-form for aesthetic purposes. 