### PR TITLE
Gpu upgrade. resolves #45

### DIFF
--- a/app/launch.py
+++ b/app/launch.py
@@ -36,48 +36,44 @@ import pytz
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 
-GPU_DEV = 'gpu_dev'
-GPU_PROD = 'gpu_prod'
-GPU_DEV_W_R = 'gpu_dev_w_r'
-GPU_PROD_W_R = 'gpu_prod_w_r'
-NO_GPU_DEV = 'no_gpu_dev'
-NO_GPU_DEV_W_R = 'no_gpu_dev_w_r'
+AVAIL_DEVICES=set(['0','1','2','3'])
+
 ERI_IMAGES = {
-    GPU_DEV: {
+    'single_gpu': {
         'image': 'eri_dev:latest',
         'auto_remove': True,
         'detach': True,
-        'ports': {8888: 8889},
-        'NV_GPU': '0',
+        'ports': {8888: 'auto'},
+        'NV_GPU': 1,
     },
-    GPU_PROD: {
-        'image': 'eri_prod:latest',
+    'multi_gpu': {
+        'image': 'eri_dev:latest',
         'auto_remove': True,
         'detach': True,
-        'ports': {8888: 8888},
-        'NV_GPU': '1',
+        'ports': {8888: 'auto'},
+        'NV_GPU': 2,
     },
-    GPU_DEV_W_R: {
+    'single_gpu_w_r': {
         'image': 'eri_dev_p_r:latest',
         'auto_remove': True,
         'detach': True,
-        'ports': {8888: 8889, 8787: 8788},
-        'NV_GPU': '0',
+        'ports': {8888: 'auto', 8787: 'auto'},
+        'NV_GPU': 1,
     },
-    GPU_PROD_W_R: {
-        'image': 'eri_prod_p_r:latest',
+    'multi_gpu_w_r': {
+        'image': 'eri_dev_p_r:latest',
         'auto_remove': True,
         'detach': True,
-        'ports': {8888: 8888, 8787: 8787},
-        'NV_GPU': '1',
+        'ports': {8888: 'auto', 8787: 'auto'},
+        'NV_GPU': 2,
     },
-    NO_GPU_DEV: {
+    'no_gpu': {
         'image': 'eri_nogpu_dev:latest',
         'auto_remove': True,
         'detach': True,
         'ports': {8888: 'auto'},
     },
-    NO_GPU_DEV_W_R: {
+    'no_gpu_w_r': {
         'image': 'eri_nogpu_dev_p_r:latest',
         'auto_remove': True,
         'detach': True,
@@ -85,8 +81,6 @@ ERI_IMAGES = {
     },
 }
 GPU_IMAGES = [k for (k, v) in ERI_IMAGES.items() if 'NV_GPU' in v]
-PROD_IMAGES = [k for (k, v) in ERI_IMAGES.items() if 'prod' in v['image']]
-DEV_IMAGES = [k for (k, v) in ERI_IMAGES.items() if 'dev' in v['image']]
 JUPYTER_IMAGES = [
     k for (k, v) in ERI_IMAGES.items() if 8888 in v.get('ports', {})
 ]
@@ -120,6 +114,16 @@ def _image_lookup(k, v):
 
     return None, None
 
+def _update_avail_devices(client=None):
+    """update set of gpus available for use"""
+    available_devices = set(['0','1','2','4'])
+    client = client or docker.from_env()
+    for c in client.countainers.list():
+        gpus = _env_lookup(c, 'NVIDIA_VISIBLE_DEVICES')
+        if gpus:
+            available_devices.difference_update(gpus.split(','))
+
+    return available_devices
 
 def _running_images(client=None, ignore_other_images=False):
     return [tag for c in client.containers.list() for tag in c.image.tags]
@@ -204,12 +208,12 @@ def active_eri_images(client=None, ignore_other_images=False):
     return active
 
 
-def _validate_launch(imagetype=GPU_DEV, client=None):
-    """basically, keep gpu instances unique
+def _validate_launch(imagetype='single_gpu', client=None):
+    """basically, ensure enough gpus available for use
 
     args:
         imagetype (str): module-specific enumeration of available images
-            (default: 'gpu_dev', which points to docker image `eri_dev:latest`)
+            (default: 'single_gpu', which points to docker image `eri_dev:latest`)
         client (docker.client.DockerClient): the docker client object
             (default: None, which builds the basic client using
             `docker.from_env`)
@@ -222,11 +226,13 @@ def _validate_launch(imagetype=GPU_DEV, client=None):
 
     """
     client = client or docker.from_env()
-    if imagetype in [GPU_DEV, GPU_PROD]:
-        if ERI_IMAGES[imagetype] in _running_images(client):
+    if imagetype in GPU_IMAGES:
+        if ERI_IMAGES[imagetype]['NV_GPU'] > len(AVAIL_DEVICES):
             return (
                 False,
-                "only one instance of {} allowed at a time".format(imagetype)
+                "only {} gpus available at this time".format(
+                    len(AVAIL_DEVICES)
+                    )
             )
         else:
             return True, None
@@ -284,19 +290,19 @@ def _find_open_port(start=8890, stop=9000):
     )
 
 
-def launch(username, imagetype=GPU_DEV, jupyter_pwd=None, **kwargs):
+def launch(username, imagetype='single_gpu', jupyter_pwd=None, **kwargs):
     """launch a docker container for user `username` of type `imagetype`
 
     args:
         username (str): linux user name, used for mounting home directories
         imagetype (str): module-specific enumeration of available images
-            (default: 'gpu_dev', which points to docker image `eri_dev:latest`)
+            (default: 'single_gpu', which points to docker image `eri_dev:latest`)
         jupyter_pwd (str): password for jupyter notebook signin
         kwargs (dict): all other keyword args are passed to the
             `client.containers.run` function
 
     returns:
-        dict: json-able response string declaring the launched contianer id and
+        dict: json-able response string declaring the launched container id and
             possibly other important information, or an error message if
             launching failed for some reason
 
@@ -392,10 +398,11 @@ def launch(username, imagetype=GPU_DEV, jupyter_pwd=None, **kwargs):
         # this prevents bus error when running pytorch in docker containers
         # see https://github.com/pytorch/pytorch/issues/2244
         imagedict['shm_size'] = '8G'
+        gpu_ids = [AVAIL_DEVICES.pop() for i in range(imagedict.pop('NV_GPU'))]
         _update_environment(
             imagedict,
             'NVIDIA_VISIBLE_DEVICES',
-            imagedict.pop('NV_GPU')
+            ','.join(gpu_ids)
         )
     else:
         _update_environment(
@@ -424,12 +431,15 @@ def launch(username, imagetype=GPU_DEV, jupyter_pwd=None, **kwargs):
     for attr in ['id', 'name', 'status']:
         d[attr] = getattr(container, attr)
 
+    AVAIL_DEVICES = _update_avail_devices(client)
+    
     return d
 
 
 def kill(docker_id):
     try:
-        docker.from_env().containers.get(docker_id).kill()
+        client = docker.from_env()
+        client.containers.get(docker_id).kill()
         d = {
             'message': 'container killed successfully',
             'status': SUCCESS,
@@ -439,6 +449,8 @@ def kill(docker_id):
         d['error_details'] = str(e)
 
     d['docker_id'] = docker_id
+
+    AVAIL_DEVICES = _update_avail_devices(client)
 
     return d
 
@@ -456,7 +468,7 @@ def parse_args():
     imagetype = "type of image to launch"
     parser.add_argument(
         "-t", "--imagetype", help=imagetype, choices=ERI_IMAGES.keys(),
-        default=GPU_DEV
+        default='single_gpu'
     )
 
     jupyter_pwd = (

--- a/app/launchapp.py
+++ b/app/launchapp.py
@@ -17,10 +17,10 @@ FLASH_CLS = {
 def home():
     launched_sessions = launch.active_eri_images(ignore_other_images=True)
 
-    if len(launch.NVIDIA_USABLE_DEVICES) > 1:
+    if len(launch.AVAIL_DEVICES) > 1:
         sessoptions = list(launch.ERI_IMAGES.keys())
         disabled_options = {}
-    elif len(launch.NVIDIA_USABLE_DEVICES) == 1:
+    elif len(launch.AVAIL_DEVICES) == 1:
         sessoptions = [k for k in launch.ERI_IMAGES.keys() if 'multi' not in k]
         disabled_options = {k for k in launch.ERI_IMAGES.keys() if 'multi' in k}
     else:

--- a/app/launchapp.py
+++ b/app/launchapp.py
@@ -19,17 +19,20 @@ def home():
 
     if len(launch.NVIDIA_USABLE_DEVICES) > 1:
         sessoptions = list(launch.ERI_IMAGES.keys())
+        disabled_options = {}
+    elif len(launch.NVIDIA_USABLE_DEVICES) == 1:
+        sessoptions = [k for k in launch.ERI_IMAGES.keys() if 'multi' not in k]
+        disabled_options = {k for k in launch.ERI_IMAGES.keys() if 'multi' in k}
     else:
-        sessoptions = [k for k in launch.ERI_IMAGES.keys() if 'SINGLE' in k]
+        sessoptions = [k for k in launch.ERI_IMAGES.keys() if 'no_gpu' in k]
+        disabled_options = {
+            k for k in launch.ERI_IMAGES.keys() if 'no_gpu' not in k
+        }
 
     return render_template(
         'index.html',
         launched_sessions=launched_sessions,
-        disabled_options={
-            ls['imagetype']
-            for ls in launched_sessions
-            if ls['imagetype'] in launch.GPU_IMAGES
-        },
+        disabled_options=disabled_options,
         sessoptions=sessoptions,
     )
 

--- a/app/launchapp.py
+++ b/app/launchapp.py
@@ -16,6 +16,12 @@ FLASH_CLS = {
 @app.route('/', methods=['GET'])
 def home():
     launched_sessions = launch.active_eri_images(ignore_other_images=True)
+
+    if len(launch.NVIDIA_USABLE_DEVICES) > 1:
+        sessoptions = list(launch.ERI_IMAGES.keys())
+    else:
+        sessoptions = [k for k in launch.ERI_IMAGES.keys() if 'SINGLE' in k]
+
     return render_template(
         'index.html',
         launched_sessions=launched_sessions,
@@ -24,7 +30,7 @@ def home():
             for ls in launched_sessions
             if ls['imagetype'] in launch.GPU_IMAGES
         },
-        sessoptions=list(launch.ERI_IMAGES.keys()),
+        sessoptions=sessoptions,
     )
 
 


### PR DESCRIPTION
Reconfigured launchapp to take advantage of 4 gpus.
Supported launch configurations:
- `no_gpu`: python-only container with no gpu attached
- `single_gpu`: python-only container with one gpu attached
- `multi_gpu`: python-only container with 2 gpus attached
- `single_gpu_w_r`: python and R container with 1 gpu attached
- `multi_gpu_w_r`: python and R container with 2 gpus attached
- `no_gpu_w_r`: python and R container with no gpu attached

Image selection logic was refactored so that only 2 underlying images are required: `eri_dev:latest` and `eri_dev_p_r:latest` (though these can be renamed to something more appropriate and changed in the `ERI_IMAGES` dict). This negates the need for the `eri_prod` and `eri_prod_p_r` folders.

Users are presented with configuration options based on the number of available GPUs remaining. The remaining GPUs are tracked by the `AVAIL_DEVICES` global, which is updated any time a new container is launched or an existing container is killed. With a little more work, the app could be extended to allow users to select the number of gpus they require. That's a discussion for a later date though.

