### PR TITLE
Upgrade to TF 1.4.0 and PyTorch 1.2.0

### DIFF
--- a/eri_python/Dockerfile
+++ b/eri_python/Dockerfile
@@ -74,6 +74,7 @@ RUN python3 -m pip --no-cache-dir install \
         sqlalchemy \
         tables \
         tqdm \
+        virtualenv \
         xlrd
 
 RUN python3 -m pip --no-cache-dir install jupyterlab ipywidgets ipympl \

--- a/eri_python/Dockerfile
+++ b/eri_python/Dockerfile
@@ -5,11 +5,16 @@ FROM tensorflow/tensorflow:1.14.0-gpu-py3
 LABEL creator="Zach Lamberty <zach.lamberty@elderresearch.com>"
 LABEL maintainer="Andrew Stewart <andrew.stewart@elderresearch.com>"
 
-RUN apt update && apt -y install locales
-RUN locale-gen en_US.UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
+
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+
+RUN apt update && apt -y install locales
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && /usr/sbin/update-locale LANG=en_US.UTF-8
 
 # add microsoft repository for mssql
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \

--- a/eri_python/Dockerfile
+++ b/eri_python/Dockerfile
@@ -1,6 +1,6 @@
 # based almost entirely off of the tensorflow/tensorflow gpu-based docker image,
 # with slight tweaks for our personal use
-FROM tensorflow/tensorflow:1.13.1-gpu-py3
+FROM tensorflow/tensorflow:1.14.0-gpu-py3
 
 LABEL creator="Zach Lamberty <zach.lamberty@elderresearch.com>"
 LABEL maintainer="Andrew Stewart <andrew.stewart@elderresearch.com>"
@@ -13,7 +13,7 @@ ENV LC_ALL en_US.UTF-8
 
 # add microsoft repository for mssql
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-        && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+        && curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # install mssql drivers
 RUN apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql17
@@ -23,7 +23,7 @@ RUN apt-get install -y openssh-server swig unixodbc-dev libpq-dev \
 	&& apt-get install -y graphviz libicu-dev
 
 # install nodejs
-RUN apt-get install -y python-software-properties \
+RUN apt-get install -y software-properties-common \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y nodejs \
     && apt-get purge -y python-software-properties
@@ -83,8 +83,7 @@ RUN python3 -m pip --no-cache-dir install jupyterlab ipywidgets ipympl \
     && jupyter labextension install jupyter-matplotlib
 
 # pytorch is also special, install from a wheel on their webpage
-RUN pip --no-cache-dir install http://download.pytorch.org/whl/cu100/torch-1.1.0-cp35-cp35m-linux_x86_64.whl
-RUN pip install torchvision
+RUN pip --no-cache-dir install torch==1.2.0 torchvision
 
 # onnx requires some additional *nix libraries
 RUN apt-get update && \
@@ -100,7 +99,7 @@ RUN apt-get install --no-install-recommends -y less git vim
 
 # install spacy `en` model and set relevant environment variables
 # c.f. https://github.com/explosion/spaCy/issues/1721
-RUN python3 -m spacy download en 
+RUN python3 -m spacy download en
 RUN python3 -m spacy download en_core_web_lg
 
 # download some of the nltk libraries

--- a/eri_python_r/Dockerfile
+++ b/eri_python_r/Dockerfile
@@ -2,7 +2,7 @@ FROM eri_python:latest
 
 # update the cran deb repo source
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/'
+RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends default-jre default-jdk

--- a/eri_python_r/Dockerfile
+++ b/eri_python_r/Dockerfile
@@ -1,7 +1,9 @@
 FROM eri_python:latest
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # update the cran deb repo source
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
 
 RUN apt-get update


### PR DESCRIPTION
Significant changes in this update:
1. Upgrade to Tensorflow 1.4.0
2. Starting with version 1.4.0, Tensorflow docker images are now based on Ubuntu 18.04 and includes Python 3.6.
3. Upgrade to PyTorch 1.2.0